### PR TITLE
Sqlalchemy 1.4 compatibility

### DIFF
--- a/sqlalchemy_continuum/builder.py
+++ b/sqlalchemy_continuum/builder.py
@@ -182,6 +182,8 @@ class Builder(object):
         """
         for cls in version_classes:
             for prop in sa.inspect(cls).iterate_properties:
+                if prop.key == 'versions':
+                    continue
                 getattr(cls, prop.key).impl.active_history = True
 
     def create_column_aliases(self, version_classes):

--- a/sqlalchemy_continuum/factory.py
+++ b/sqlalchemy_continuum/factory.py
@@ -8,7 +8,9 @@ class ModelFactory(object):
         Create model class but only if it doesn't already exist
         in declarative model registry.
         """
-        registry = class_registry(manager.declarative_base)
-        if self.model_name not in registry:
+        for mapper in manager.declarative_base.registry.mappers:
+            clsname = mapper.class_.__name__
+            if self.model_name == clsname:
+                return mapper.class_
+        else:
             return self.create_class(manager)
-        return registry[self.model_name]

--- a/sqlalchemy_continuum/factory.py
+++ b/sqlalchemy_continuum/factory.py
@@ -1,5 +1,3 @@
-from .utils import class_registry
-
 class ModelFactory(object):
     model_name = None
 

--- a/sqlalchemy_continuum/factory.py
+++ b/sqlalchemy_continuum/factory.py
@@ -1,3 +1,5 @@
+from .utils import class_registry
+
 class ModelFactory(object):
     model_name = None
 
@@ -6,7 +8,7 @@ class ModelFactory(object):
         Create model class but only if it doesn't already exist
         in declarative model registry.
         """
-        registry = manager.declarative_base._decl_class_registry
+        registry = class_registry(manager.declarative_base)
         if self.model_name not in registry:
             return self.create_class(manager)
         return registry[self.model_name]

--- a/sqlalchemy_continuum/manager.py
+++ b/sqlalchemy_continuum/manager.py
@@ -145,8 +145,8 @@ class VersioningManager(object):
             'after_insert': self.track_inserts,
         }
         self.class_config_listeners = {
-            'instrument_class': self.builder.instrument_versioned_classes,
-            'after_configured': self.builder.configure_versioned_classes,
+            'instrument_class': (self.builder.instrument_versioned_classes, {}),
+            'after_configured': (self.builder.configure_versioned_classes, {'once': True}),
         }
 
         # A dictionary of units of work. Keys as connection objects and values
@@ -221,8 +221,8 @@ class VersioningManager(object):
         :param mapper:
             SQLAlchemy mapper to apply the class configuration listeners to
         """
-        for event_name, listener in self.class_config_listeners.items():
-            sa.event.listen(mapper, event_name, listener)
+        for event_name, (listener, kwargs) in self.class_config_listeners.items():
+            sa.event.listen(mapper, event_name, listener, **kwargs)
 
     def remove_class_configuration_listeners(self, mapper):
         """

--- a/sqlalchemy_continuum/transaction.py
+++ b/sqlalchemy_continuum/transaction.py
@@ -133,12 +133,14 @@ class TransactionFactory(ModelFactory):
 
             if manager.user_cls:
                 user_cls = manager.user_cls
-                registry = class_registry(manager.declarative_base)
 
                 if isinstance(user_cls, six.string_types):
-                    try:
-                        user_cls = registry[user_cls]
-                    except KeyError:
+                    for mapper in manager.declarative_base.registry.mappers:
+                        clsname = mapper.class_.__name__
+                        if self.model_name == clsname:
+                            user_cls = mapper.class_
+                            break
+                    else:
                         raise ImproperlyConfigured(
                             'Could not build relationship between Transaction'
                             ' and %s. %s was not found in declarative class '

--- a/sqlalchemy_continuum/transaction.py
+++ b/sqlalchemy_continuum/transaction.py
@@ -16,7 +16,6 @@ from .dialects.postgresql import (
 )
 from .exc import ImproperlyConfigured
 from .factory import ModelFactory
-from .utils import class_registry
 
 
 @compiles(sa.types.BigInteger, 'sqlite')

--- a/sqlalchemy_continuum/transaction.py
+++ b/sqlalchemy_continuum/transaction.py
@@ -16,6 +16,7 @@ from .dialects.postgresql import (
 )
 from .exc import ImproperlyConfigured
 from .factory import ModelFactory
+from .utils import class_registry
 
 
 @compiles(sa.types.BigInteger, 'sqlite')
@@ -132,7 +133,7 @@ class TransactionFactory(ModelFactory):
 
             if manager.user_cls:
                 user_cls = manager.user_cls
-                registry = manager.declarative_base._decl_class_registry
+                registry = class_registry(manager.declarative_base)
 
                 if isinstance(user_cls, six.string_types):
                     try:

--- a/sqlalchemy_continuum/transaction.py
+++ b/sqlalchemy_continuum/transaction.py
@@ -136,7 +136,7 @@ class TransactionFactory(ModelFactory):
                 if isinstance(user_cls, six.string_types):
                     for mapper in manager.declarative_base.registry.mappers:
                         clsname = mapper.class_.__name__
-                        if self.model_name == clsname:
+                        if user_cls == clsname:
                             user_cls = mapper.class_
                             break
                     else:

--- a/sqlalchemy_continuum/utils.py
+++ b/sqlalchemy_continuum/utils.py
@@ -450,15 +450,3 @@ class VersioningClauseAdapter(sa.sql.visitors.ReplacingCloningVisitor):
 
 def adapt_columns(expr):
     return VersioningClauseAdapter().traverse(expr)
-
-
-def class_registry(cls):
-    """
-    Function for dynamically getting class
-    registry dictionary from specified model.
-    """
-    try:
-        return dict(cls._sa_registry._class_registry)
-    except:
-        return dict(cls._decl_class_registry)
-    return

--- a/sqlalchemy_continuum/utils.py
+++ b/sqlalchemy_continuum/utils.py
@@ -450,3 +450,15 @@ class VersioningClauseAdapter(sa.sql.visitors.ReplacingCloningVisitor):
 
 def adapt_columns(expr):
     return VersioningClauseAdapter().traverse(expr)
+
+
+def class_registry(cls):
+    """
+    Function for dynamically getting class
+    registry dictionary from specified model.
+    """
+    try:
+        return dict(cls._sa_registry._class_registry)
+    except:
+        return dict(cls._decl_class_registry)
+    return


### PR DESCRIPTION
This PR does the following:
* Replace use of _decl_class_registry with manager.declarative_base.registry.mappers when collecting Model class from class name
* Ensure that configure_versioned_classes() is only called once on 'after_configure' event.  SQLAlchemy 1.4 calls configure again when creating the parent_version relationship, causing configure_versioned_classes() to be called recursively.  All sorts of odd behaviour result, including the versioned class relationships being missing.